### PR TITLE
feat(patients): add SearchPatients endpoint and query handler

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -1,0 +1,24 @@
+# LifeCare Project Features
+
+## Search Patients
+**Module:** Patients  
+**Date Implemented:** 2026-02-10  
+**Implemented By:** Berry Mundia
+
+### Feature Description
+Allows users to search patients by first/last name or city. Supports partial matches and returns a list of patients.
+
+### Technical Details
+- **CQRS Implementation:** `SearchPatientsQuery` + `SearchPatientsQueryHandler`
+- **Repository Method:** `IPatientRepository.SearchPatientsAsync(name, city)`
+- **Database Access:** EF Core (`HospitalDbContext`)
+- **Return Type:** `IReadOnlyList<Patient>`
+
+### API Endpoint
+| Method | Endpoint | Query Params | Response |
+|--------|----------|--------------|----------|
+| GET    | `/api/patients/search` | `name` (optional), `city` (optional) | `{ success: true, data: [PatientDto] }` |
+
+### Sample Usage
+```http
+GET /api/patients/search?name=John&city=Nairobi

--- a/LifeCare.API/Controllers/PatientsController.cs
+++ b/LifeCare.API/Controllers/PatientsController.cs
@@ -177,6 +177,17 @@ namespace LifeCare.API.Controllers
             return Ok(new{success = true, data = patient });
 
         }
+        //
+        // SEARCH PATIENTS
+        //
+        [HttpGet("search")]
+        public async Task<IActionResult> SearchPatients([FromQuery] string? name, [FromQuery] string? city)
+        {
+            var query = new SearchPatientQuery(name, city);
+            var patients = await _mediator.Send(query);
+    
+            return Ok(new { success = true, data = patients });
+        }
         
     }
 

--- a/LifeCare.Application/Interfaces/Repositories/IPatientRepository.cs
+++ b/LifeCare.Application/Interfaces/Repositories/IPatientRepository.cs
@@ -18,6 +18,7 @@ namespace LifeCare.Application.Interfaces.Repositories
         Task SaveChangesAsync(CancellationToken cancellationToken = default);
         Task<List<Patient>> GetAllAsync();
         Task<Patient?> GetByPhoneNumberAsync(string phoneNumber);
+        Task<IReadOnlyList<Patient>> SearchPatientsAsync(string? name, string? city);
 
 
     }

--- a/LifeCare.Application/Patients/Queries/SearchPatientQuery.cs
+++ b/LifeCare.Application/Patients/Queries/SearchPatientQuery.cs
@@ -1,0 +1,6 @@
+using LifeCare.Domain.Patients;
+using MediatR;
+
+namespace LifeCare.Application.Patients.Queries;
+
+public record SearchPatientQuery(string? Name, string? City) : IRequest<IReadOnlyList<Patient>>;

--- a/LifeCare.Application/Patients/Queries/SearchPatientQueryHandler.cs
+++ b/LifeCare.Application/Patients/Queries/SearchPatientQueryHandler.cs
@@ -1,0 +1,25 @@
+using LifeCare.Application.Interfaces.Repositories;
+using LifeCare.Domain.Patients;
+using MediatR;
+
+namespace LifeCare.Application.Patients.Queries;
+
+public class SearchPatientQueryHandler
+    : IRequestHandler<SearchPatientQuery, IReadOnlyList<Patient>>
+{
+    private readonly IPatientRepository _patientRepository;
+
+    public SearchPatientQueryHandler(IPatientRepository patientRepository)
+    {
+        _patientRepository = patientRepository;
+    }
+
+    public async Task<IReadOnlyList<Patient>> Handle(
+        SearchPatientQuery request,
+        CancellationToken cancellationToken)
+    {
+        return await _patientRepository.SearchPatientsAsync(
+            request.Name,
+            request.City);
+    }
+}

--- a/LifeCare.Infrastructure/Repositories/InMemoryPatientRepository.cs
+++ b/LifeCare.Infrastructure/Repositories/InMemoryPatientRepository.cs
@@ -47,6 +47,8 @@ namespace LifeCare.Infrastructure.Repositories
             );
         }
 
+
+
         public Task<int> GetNextMrnSequenceAsync()
         {
             var currentYear = DateTime.Now.Year;
@@ -77,6 +79,7 @@ namespace LifeCare.Infrastructure.Repositories
                 _patients.Remove(existing);
                 _patients.Add(patient);
             }
+
             return Task.CompletedTask;
         }
 
@@ -84,6 +87,31 @@ namespace LifeCare.Infrastructure.Repositories
         {
             return Task.CompletedTask;
         }
+
+        public Task<IReadOnlyList<Patient>> SearchPatientsAsync(string? name, string? city)
+        {
+            IEnumerable<Patient> query = _patients;
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                query = query.Where(p =>
+                    p.FirstName.Contains(name, StringComparison.OrdinalIgnoreCase) ||
+                    p.LastName.Contains(name, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!string.IsNullOrWhiteSpace(city))
+            {
+                query = query.Where(p =>
+                    p.City.Contains(city, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var result = query
+                .OrderByDescending(p => p.CreatedAt)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<Patient>>(result);
+        }
+
 
         // -----------------------
         // MRN PARSER (PRIVATE)
@@ -102,4 +130,6 @@ namespace LifeCare.Infrastructure.Repositories
             return (year, sequence);
         }
     }
+
 }
+    

--- a/LifeCare.Infrastructure/Repositories/PatientRepository.cs
+++ b/LifeCare.Infrastructure/Repositories/PatientRepository.cs
@@ -99,5 +99,26 @@ namespace LifeCare.Infrastructure.Repositories
             return await _context.Patients
                 .FirstOrDefaultAsync(p => p.PhoneNumber == phoneNumber);
         }
+
+        public async Task<IReadOnlyList<Patient>> SearchPatientsAsync(string? name, string? city)
+        {
+            IQueryable<Patient> query = _context.Patients;
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                query = query.Where(p =>
+                    p.FirstName.Contains(name) ||
+                    p.LastName.Contains(name)
+                );
+                
+            }
+
+            if (!string.IsNullOrWhiteSpace(city))
+            {
+                query = query.Where(p => p.City == city);
+            }
+            return await query.ToListAsync();
+        }
+
     }
 }


### PR DESCRIPTION
- Implemented SearchPatientsQuery and SearchPatientsQueryHandler
- Added API endpoint GET /patients/search with optional name and city filters
- Returns standardized JSON response with patient details, age, fullName, and guardian info
- Supports nullable query parameters and handles empty results